### PR TITLE
Allow passing source token directly to the task

### DIFF
--- a/lib/logtail-rails/tasks/logtail.rake
+++ b/lib/logtail-rails/tasks/logtail.rake
@@ -1,10 +1,11 @@
 namespace :logtail do
   desc 'Install a default config/initializers/logtail.rb file'
 
-  def content
+  PLACEHOLDER = '<SOURCE_TOKEN>'.freeze
+  def content(source_token = nil)
     <<~RUBY
       if ENV['LOGTAIL_SKIP_LOGS'].blank? && !Rails.env.test?
-        http_device = Logtail::LogDevices::HTTP.new('<SOURCE_TOKEN>')
+        http_device = Logtail::LogDevices::HTTP.new('#{source_token || PLACEHOLDER}')
         Rails.logger = Logtail::Logger.new(http_device)
       else
         Rails.logger = Logtail::Logger.new(STDOUT)
@@ -15,6 +16,7 @@ namespace :logtail do
   task install: :environment do
     quiet = ENV['quiet']
     force = ENV['force']
+    source_token = ENV['source_token']
 
     config_file = 'config/initializers/logtail.rb'
 
@@ -23,7 +25,7 @@ namespace :logtail do
       next
     end
 
-    File.open(config_file, 'w') { |out| out.puts(content) }
+    File.open(config_file, 'w') { |out| out.puts(content(source_token) }
 
     puts <<~EOF unless quiet
       Installed a default configuration file at #{config_file}.

--- a/lib/logtail-rails/tasks/logtail.rake
+++ b/lib/logtail-rails/tasks/logtail.rake
@@ -25,7 +25,7 @@ namespace :logtail do
       next
     end
 
-    File.open(config_file, 'w') { |out| out.puts(content(source_token) }
+    File.open(config_file, 'w') { |out| out.puts(content(source_token)) }
 
     puts <<~EOF unless quiet
       Installed a default configuration file at #{config_file}.


### PR DESCRIPTION
This would allow the user to avoid editing the config file after he/she runs the installation command:
```bash
rake logtail:install source_token=abcd123
```

... and it would simplify the instructions and allow us to make it all copy-pastable.