### PR TITLE
Replace TaggedLogging even when it is a module and not a class

### DIFF
--- a/lib/logtail-rails/overrides/active_support_3_tagged_logging.rb
+++ b/lib/logtail-rails/overrides/active_support_3_tagged_logging.rb
@@ -15,7 +15,7 @@ begin
 
   # Instead of patching the class we're pulling the code from Rails master. This brings in
   # a number of improvements while also addressing the issue above.
-  if ActiveSupport::TaggedLogging.instance_of?(Class)
+  if defined?(ActiveSupport::TaggedLogging)
     ActiveSupport.send(:remove_const, :TaggedLogging)
 
     require "active_support/core_ext/module/delegation"


### PR DESCRIPTION
This fix requires also a change in the ruby gem: https://github.com/logtail/logtail-ruby/pull/7