### PR TITLE
reduce rails dependencies

### DIFF
--- a/lib/logtail-rails.rb
+++ b/lib/logtail-rails.rb
@@ -1,7 +1,11 @@
 require "logtail-rails/overrides"
 
 require "logtail"
-require "rails"
+
+require "rails/railtie"
+require "active_record"
+require "rack"
+
 require "logtail-rails/active_support_log_subscriber"
 require "logtail-rails/config"
 require "logtail-rails/railtie"

--- a/logtail-rails.gemspec
+++ b/logtail-rails.gemspec
@@ -29,7 +29,10 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "logtail", "~> 0.1"
   spec.add_runtime_dependency "logtail-rack", "~> 0.1"
-  spec.add_runtime_dependency "rails", ">= 3.0.0"
+
+  spec.add_runtime_dependency 'activerecord', '>= 3.0.0'
+  spec.add_runtime_dependency 'railties', '>= 3.0.0'
+  spec.add_runtime_dependency 'actionpack', '>= 3.0.0'
 
   spec.add_development_dependency "bundler", ">= 0.0"
 


### PR DESCRIPTION
Hey there,

I noticed that your ruby gem was including all of rails. I've trimmed it down quite a bit to just the dependencies that this gem really needs.

A problem I encountered was that the test coverage didn't seem very good and the build was failing upon install. Please take a look at this problem in the future.

For the more optional dependencies, I would add them as either optional or as development dependencies.