### PR TITLE
Fix: Don't inadvertently define Object#content

### DIFF
--- a/lib/logtail-rails/tasks/logtail.rake
+++ b/lib/logtail-rails/tasks/logtail.rake
@@ -2,20 +2,21 @@ namespace :logtail do
   desc 'Install a default config/initializers/logtail.rb file'
 
   PLACEHOLDER = '<SOURCE_TOKEN>'.freeze
-  def content(source_token = nil)
-    <<~RUBY
-      Rails.application.configure do
-        if ENV['LOGTAIL_SKIP_LOGS'].blank? && !Rails.env.test?
-          http_device = Logtail::LogDevices::HTTP.new('#{source_token || PLACEHOLDER}')
-          config.logger = Logtail::Logger.new(http_device)
-        else
-          config.logger = Logtail::Logger.new(STDOUT)
-        end
-      end
-    RUBY
-  end
 
   task install: :environment do
+    def content(source_token = nil)
+      <<~RUBY
+        Rails.application.configure do
+          if ENV['LOGTAIL_SKIP_LOGS'].blank? && !Rails.env.test?
+            http_device = Logtail::LogDevices::HTTP.new('#{source_token || PLACEHOLDER}')
+            config.logger = Logtail::Logger.new(http_device)
+          else
+            config.logger = Logtail::Logger.new(STDOUT)
+          end
+        end
+      RUBY
+    end
+
     quiet = ENV['quiet']
     force = ENV['force']
     source_token = ENV['source_token']


### PR DESCRIPTION
    Fix: Don't inadvertently define Object#content

    In the logtail rake task file, we were defining a method in the
    "logtail" rake namespace. Unfortunately, methods defined here are
    defined in global scope, so we ended up defining Object#content.

    This has unintended side effects. Example: factorybot relies on
    method_missing in factory definitions. So if you have a factory
    attribute called "content", then the logtail Object#content would be
    called instead of factorybot's method_missing.

    Move the method definition inside the rake task definition - where it is
    locally scoped as originally intended.
