### PR TITLE
Schedule periodically running test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '20 5 * * 1'
 
 jobs:
   test:


### PR DESCRIPTION
Since any new released dependency can potentially break our tests, I would suggest running them periodically (at 5:20 every Monday).

We're not doing many changes in this repo, so it would be nice to see whether tests are passing on `main` in a recent build.