### PR TITLE
Add check for  jruby-9.4.3.0 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,15 @@ jobs:
 
       matrix:
         ruby-version:
+          - 3.2.2
+          - 3.1.4
+          - 3.0.6
+          - 2.7.2
+          - 2.6.6
+          - 2.5.8
           - jruby-9.4.3.0
+          - jruby-9.2.14.0
+          - truffleruby-21.0.0
         gemfile:
           - rails-7.0
           - rails-6.1
@@ -40,6 +48,8 @@ jobs:
             ruby-version: 3.1.4
           - gemfile: rails-5.2
             ruby-version: 3.0.6
+          - gemfile: rails-5.2
+            ruby-version: jruby-9.4.3.0
 
           - gemfile: rails-5.1
             ruby-version: 3.2.2
@@ -47,6 +57,8 @@ jobs:
             ruby-version: 3.1.4
           - gemfile: rails-5.1
             ruby-version: 3.0.6
+          - gemfile: rails-5.1
+            ruby-version: jruby-9.4.3.0
 
           - gemfile: rails-5.0
             ruby-version: 3.2.2
@@ -54,6 +66,8 @@ jobs:
             ruby-version: 3.1.4
           - gemfile: rails-5.0
             ruby-version: 3.0.6
+          - gemfile: rails-5.0
+            ruby-version: jruby-9.4.3.0
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,15 +16,7 @@ jobs:
 
       matrix:
         ruby-version:
-          - 3.2.2
-          - 3.1.4
-          - 3.0.6
-          - 2.7.2
-          - 2.6.6
-          - 2.5.8
-          - jruby-9.2.14.0
           - jruby-9.4.3.0
-          - truffleruby-21.0.0
         gemfile:
           - rails-7.0
           - rails-6.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           - 2.6.6
           - 2.5.8
           - jruby-9.2.14.0
+          - jruby-9.4.3.0
           - truffleruby-21.0.0
         gemfile:
           - rails-7.0


### PR DESCRIPTION
`jruby-9.4.3.0` works with Rails 6.0, 6.1, and 7.0.