### PR TITLE
Fix truffle ruby compatibility check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,23 +16,15 @@ jobs:
 
       matrix:
         ruby-version:
-          - truffleruby-19.3.0
-          - truffleruby-19.3.1
-          - truffleruby-20.0.0
-          - truffleruby-20.1.0
-          - truffleruby-20.2.0
-          - truffleruby-20.3.0
-          - truffleruby-21.0.0
-          - truffleruby-21.1.0
-          - truffleruby-21.2.0
-          - truffleruby-21.2.0.1
-          - truffleruby-21.3.0
-          - truffleruby-22.0.0.2
-          - truffleruby-22.1.0
-          - truffleruby-22.2.0
-          - truffleruby-22.3.0
-          - truffleruby-22.3.1
+          - 3.2.2
+          - 3.1.4
+          - 3.0.6
+          - 2.7.2
+          - 2.6.6
+          - 2.5.8
+          - jruby-9.2.14.0
           - truffleruby-23.0.0
+          - truffleruby-22.1.0
         gemfile:
           - rails-7.0
           - rails-6.1
@@ -40,6 +32,46 @@ jobs:
           - rails-5.2
           - rails-5.1
           - rails-5.0
+        exclude:
+          - gemfile: rails-7.0
+            ruby-version: 2.6.6
+          - gemfile: rails-7.0
+            ruby-version: 2.5.8
+          - gemfile: rails-7.0
+            ruby-version: jruby-9.2.14.0
+
+          - gemfile: rails-5.2
+            ruby-version: 3.2.2
+          - gemfile: rails-5.2
+            ruby-version: 3.1.4
+          - gemfile: rails-5.2
+            ruby-version: 3.0.6
+          - gemfile: rails-5.2
+            ruby-version: truffleruby-23.0.0
+          - gemfile: rails-5.2
+            ruby-version: truffleruby-22.1.0
+
+          - gemfile: rails-5.1
+            ruby-version: 3.2.2
+          - gemfile: rails-5.1
+            ruby-version: 3.1.4
+          - gemfile: rails-5.1
+            ruby-version: 3.0.6
+          - gemfile: rails-5.1
+            ruby-version: truffleruby-23.0.0
+          - gemfile: rails-5.1
+            ruby-version: truffleruby-22.1.0
+
+          - gemfile: rails-5.0
+            ruby-version: 3.2.2
+          - gemfile: rails-5.0
+            ruby-version: 3.1.4
+          - gemfile: rails-5.0
+            ruby-version: 3.0.6
+          - gemfile: rails-5.0
+            ruby-version: truffleruby-23.0.0
+          - gemfile: rails-5.0
+            ruby-version: truffleruby-22.1.0
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,13 @@ jobs:
 
       matrix:
         ruby-version:
-          - 3.2.2
-          - 3.1.4
-          - 3.0.6
-          - 2.7.2
-          - 2.6.6
-          - 2.5.8
-          - jruby-9.2.14.0
+          - truffleruby-20.3.3
           - truffleruby-21.0.0
+          - truffleruby-21.0.0.2
+          - truffleruby-21.3.0
+          - truffleruby-22.0.0.2
+          - truffleruby-22.3.1
+          - truffleruby-23.0.0
         gemfile:
           - rails-7.0
           - rails-6.1
@@ -31,36 +30,6 @@ jobs:
           - rails-5.2
           - rails-5.1
           - rails-5.0
-        exclude:
-          - gemfile: rails-7.0
-            ruby-version: 2.6.6
-          - gemfile: rails-7.0
-            ruby-version: 2.5.8
-          - gemfile: rails-7.0
-            ruby-version: jruby-9.2.14.0
-          - gemfile: rails-7.0
-            ruby-version: truffleruby-21.0.0
-
-          - gemfile: rails-5.2
-            ruby-version: 3.2.2
-          - gemfile: rails-5.2
-            ruby-version: 3.1.4
-          - gemfile: rails-5.2
-            ruby-version: 3.0.6
-
-          - gemfile: rails-5.1
-            ruby-version: 3.2.2
-          - gemfile: rails-5.1
-            ruby-version: 3.1.4
-          - gemfile: rails-5.1
-            ruby-version: 3.0.6
-
-          - gemfile: rails-5.0
-            ruby-version: 3.2.2
-          - gemfile: rails-5.0
-            ruby-version: 3.1.4
-          - gemfile: rails-5.0
-            ruby-version: 3.0.6
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,21 @@ jobs:
 
       matrix:
         ruby-version:
-          - truffleruby-20.3.3
+          - truffleruby-19.3.0
+          - truffleruby-19.3.1
+          - truffleruby-20.0.0
+          - truffleruby-20.1.0
+          - truffleruby-20.2.0
+          - truffleruby-20.3.0
           - truffleruby-21.0.0
-          - truffleruby-21.0.0.2
+          - truffleruby-21.1.0
+          - truffleruby-21.2.0
+          - truffleruby-21.2.0.1
           - truffleruby-21.3.0
           - truffleruby-22.0.0.2
+          - truffleruby-22.1.0
+          - truffleruby-22.2.0
+          - truffleruby-22.3.0
           - truffleruby-22.3.1
           - truffleruby-23.0.0
         gemfile:


### PR DESCRIPTION
`truffleruby-21.0.0` seemed to be incompatible with the Bundler, and since it wasn't even compatible with current Rails, I suggest to check compatibility with `truffleruby-22.1.0` and `truffleruby-23.0.0`