### PR TITLE
Remove loading of tasks/logtail.rake (removed file)

### DIFF
--- a/example-project/Gemfile
+++ b/example-project/Gemfile
@@ -71,4 +71,4 @@ group :test do
   gem "webdrivers"
 end
 
-gem "logtail-rails", "~> 0.1.7"
+gem "logtail-rails", "~> 0.2.0"

--- a/lib/logtail-rails/railtie.rb
+++ b/lib/logtail-rails/railtie.rb
@@ -6,10 +6,6 @@ module Logtail
       # Installs Logtail into your Rails app automatically.
       class Railtie < ::Rails::Railtie
         railtie_name 'logtail-rails'
-        rake_tasks do
-          path = File.expand_path(__dir__)
-          load "#{path}/tasks/logtail.rake"
-        end
 
         config.logtail = Config.instance
 

--- a/lib/logtail-rails/version.rb
+++ b/lib/logtail-rails/version.rb
@@ -1,7 +1,7 @@
 module Logtail
   module Integrations
     module Rails
-      VERSION = "0.2.1"
+      VERSION = "0.2.2"
     end
   end
 end


### PR DESCRIPTION
Missed issue when testing #14, `bundle exec rails assets:precompile` fails on `LoadError`