### PR TITLE
Integrate with Sidekiq if installed

### DIFF
--- a/lib/logtail-rails.rb
+++ b/lib/logtail-rails.rb
@@ -21,6 +21,7 @@ require "logtail-rails/action_controller"
 require "logtail-rails/action_dispatch"
 require "logtail-rails/action_view"
 require "logtail-rails/active_record"
+require "logtail-rails/sidekiq"
 
 require "logtail-rails/log_entry"
 require "logtail-rails/logger"

--- a/lib/logtail-rails/logger.rb
+++ b/lib/logtail-rails/logger.rb
@@ -34,7 +34,12 @@ module Logtail
 
       logger = self.create_logger(io_device)
 
-      Sidekiq.configure_server { |config| config.logger = logger } if defined?(Sidekiq)
+      if defined?(Sidekiq)
+        Sidekiq.configure_server do |config|
+          logger = self.create_logger(io_device, config.logger) if config.logger.class == Sidekiq::Logger
+          config.logger = logger
+        end
+      end
 
       logger
     end

--- a/lib/logtail-rails/logger.rb
+++ b/lib/logtail-rails/logger.rb
@@ -32,7 +32,11 @@ module Logtail
         io_device = STDOUT
       end
 
-      self.create_logger(io_device)
+      logger = self.create_logger(io_device)
+
+      Sidekiq.configure_server { |config| config.logger = logger } if defined?(Sidekiq)
+
+      logger
     end
   end
 end

--- a/lib/logtail-rails/sidekiq.rb
+++ b/lib/logtail-rails/sidekiq.rb
@@ -1,0 +1,38 @@
+# integrates Logtail::CurrentContext with Sidekiq::Context if installed
+
+begin
+  require 'sidekiq/job_logger'
+
+  class Sidekiq::JobLogger
+    def call(_item, _queue)
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      Logtail::CurrentContext.with({ sidekiq: Sidekiq::Context.current.to_h }) do
+        @logger.info("start")
+
+        yield
+      end
+
+      Sidekiq::Context.add(:elapsed, elapsed(start))
+      Logtail::CurrentContext.with({ sidekiq: Sidekiq::Context.current.to_h }) do
+        @logger.info('done')
+      end
+    rescue Exception
+      Sidekiq::Context.add(:elapsed, elapsed(start))
+      Logtail::CurrentContext.with({ sidekiq: Sidekiq::Context.current.to_h }) do
+        @logger.info('fail')
+      end
+
+      raise
+    end
+
+    private
+
+    def elapsed(start)
+      (Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start).round(3)
+    end
+  end
+
+rescue LoadError
+  # sidekiq is not present
+end

--- a/lib/logtail-rails/version.rb
+++ b/lib/logtail-rails/version.rb
@@ -1,7 +1,7 @@
 module Logtail
   module Integrations
     module Rails
-      VERSION = "0.2.2"
+      VERSION = "0.2.3"
     end
   end
 end


### PR DESCRIPTION
Integrates with Sidekiq if the project uses it:
- Job-related logs contain info from Sidekiq::Context.
- When logger is created via `Logtail::Logger.create_default_logger()`, if will be automatically set as Sidekiq logger as well.

<img width="1361" alt="image" src="https://github.com/logtail/logtail-ruby-rails/assets/10008612/4b973db1-7d00-43ee-a3a9-585d3b9148ab">
