### PR TITLE
L-788 Fix compatibility with ActiveSupport::BroadcastLogger behavior in Rails 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - truffleruby-22.1.0
         gemfile:
           - rails-edge
+          - rails-7.1
           - rails-7.0
           - rails-6.1
           - rails-6.0
@@ -44,6 +45,13 @@ jobs:
             ruby-version: jruby-9.2.14.0
           - gemfile: rails-edge
             ruby-version: truffleruby-23.0.0
+
+          - gemfile: rails-7.1
+            ruby-version: 2.6
+          - gemfile: rails-7.1
+            ruby-version: 2.5
+          - gemfile: rails-7.1
+            ruby-version: jruby-9.2.14.0
 
           - gemfile: rails-7.0
             ruby-version: 2.6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
           - gemfile: rails-7.1
             ruby-version: 2.5
           - gemfile: rails-7.1
+            ruby-version: jruby-9.4.3.0
+          - gemfile: rails-7.1
             ruby-version: jruby-9.2.14.0
 
           - gemfile: rails-7.0

--- a/example-project/Gemfile
+++ b/example-project/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.1.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.0.6"
+gem "rails", "~> 7.1.0"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
@@ -13,7 +13,7 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 1.4"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 5.0"
+gem "puma", "~> 6.0"
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"

--- a/example-project/Gemfile
+++ b/example-project/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.2"
+ruby "3.2.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.0"

--- a/example-project/config/application.rb
+++ b/example-project/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module ExampleProject
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.1.0'
+
+gem 'logtail'
+gem 'logtail-rack'
+
+if RUBY_PLATFORM == "java"
+  gem 'mime-types', '2.6.2'
+end
+
+gemspec :path => '../'

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -1,7 +1,7 @@
 require "rails"
 require "logtail-rails/railtie"
 
-# Defualt the rails logger to nothing, each test shoould be
+# Default the rails logger to nothing, each test should be
 # responsible for setting up the logger
 logger = Logtail::Logger.new(nil) # change to STDOUT to see rails logs
 Rails.logger = logger


### PR DESCRIPTION
Fixes #30 

Specific issues with previous implementation in Rails 7.1:
1. `Rails.logger` is set to an instance of `ActiveSupport::BroadcastLogger` in bootstrap. This leads to the usage of other logger classes.
2. `Logtail::Logger` accepts structured data, other loggers don't. If other logger classes are used, `ArgumentError` will be raised when structured data are logged.
3. `ActiveSupport::Logger.logger_outputs_to?` cannot detect `@extra_loggers` in `Logtail::Logger`. This leads to loggers being registered multiple times.

This PR resolves those issues:
1. `Rails.logger` will not be reassigned in bootstrap, because `Logtail::Logger` instance will return true on `.is_a?(ActiveSupport::BroadcastLogger)`.
2. No other logger class should be directly used (only as part of `@extra_loggers`).
3. `ActiveSupport::Logger.logger_outputs_to?` should work correctly with `Logtail::Logger` due to the implementation of `broadcasts` method.

This approach was tested in `example-project` on both Rails 7.0 and 7.1, works nicely when Sidekiq gets installed and used.