### PR TITLE
L-873 Fix compatibility with Rails < 7.1

### DIFF
--- a/lib/logtail-rails/logger.rb
+++ b/lib/logtail-rails/logger.rb
@@ -18,7 +18,7 @@ module Logtail
 
     # Logtail::Logger also works as ActiveSupport::BroadcastLogger
     def is_a?(clazz)
-      return true if clazz == ::ActiveSupport::BroadcastLogger
+      return true if defined?(::ActiveSupport::BroadcastLogger) && clazz == ::ActiveSupport::BroadcastLogger
 
       super(clazz)
     end

--- a/lib/logtail-rails/logger.rb
+++ b/lib/logtail-rails/logger.rb
@@ -17,11 +17,12 @@ module Logtail
     end
 
     # Logtail::Logger also works as ActiveSupport::BroadcastLogger
-    def is_a?(clazz)
+    def kind_of?(clazz)
       return true if defined?(::ActiveSupport::BroadcastLogger) && clazz == ::ActiveSupport::BroadcastLogger
 
       super(clazz)
     end
+    alias is_a? kind_of?
 
     def broadcasts
       [self] + @extra_loggers

--- a/spec/logtail-rails/logger_spec.rb
+++ b/spec/logtail-rails/logger_spec.rb
@@ -54,7 +54,9 @@ RSpec.describe Logtail::Logger, :rails_23 => true do
 
       logger.broadcast_to(STDOUT)
 
-      expect(::ActiveSupport::Logger.logger_outputs_to?(logger, STDOUT)).to eq(true)
+      # Logger.logger_outputs_to? didn't work correctly for broadcasting loggers before, skip the assert
+      # see https://github.com/rails/rails/pull/49417/files#r1340736648
+      expect(::ActiveSupport::Logger.logger_outputs_to?(logger, STDOUT)).to eq(true) if Rails::VERSION::STRING >= "7.1"
       expect(logger.broadcasts.length).to eq(2)
 
       logger.stop_broadcasting_to(STDOUT)

--- a/spec/logtail-rails/logger_spec.rb
+++ b/spec/logtail-rails/logger_spec.rb
@@ -43,9 +43,18 @@ RSpec.describe Logtail::Logger, :rails_23 => true do
 
     it "should be considered a broadcast logger in Rails 7.1" do
       expect(logger.is_a?(::Logger)).to eq(true)
+      expect(logger).to be_kind_of(::Logger)
+
       expect(logger.is_a?(::Logtail::Logger)).to eq(true)
-      expect(logger.is_a?(::ActiveSupport::BroadcastLogger)).to eq(true) if Rails::VERSION::STRING >= "7.1"
+      expect(logger).to be_kind_of(::Logtail::Logger)
+
+      if Rails::VERSION::STRING >= "7.1"
+        expect(logger.is_a?(::ActiveSupport::BroadcastLogger)).to eq(true)
+        expect(logger).to be_kind_of(::ActiveSupport::BroadcastLogger)
+      end
+
       expect(logger.is_a?(::Rails::Application)).to eq(false)
+      expect(logger).to_not be_kind_of(::Rails::Application)
     end
 
     it "should be able to start and stop broadcast" do

--- a/spec/logtail-rails/logger_spec.rb
+++ b/spec/logtail-rails/logger_spec.rb
@@ -40,5 +40,27 @@ RSpec.describe Logtail::Logger, :rails_23 => true do
       expect(io.string).to include(',"public_info":"public_info",')
       expect(io.string).to include(',"north_pole":{"secret":"[FILTERED]"},')
     end
+
+    it "should be considered a broadcast logger in Rails 7.1" do
+      expect(logger.is_a?(::Logger)).to eq(true)
+      expect(logger.is_a?(::Logtail::Logger)).to eq(true)
+      expect(logger.is_a?(::ActiveSupport::BroadcastLogger)).to eq(true) if Rails::VERSION::STRING >= "7.1"
+      expect(logger.is_a?(::Rails::Application)).to eq(false)
+    end
+
+    it "should be able to start and stop broadcast" do
+      expect(::ActiveSupport::Logger.logger_outputs_to?(logger, STDOUT)).to eq(false)
+      expect(logger.broadcasts.length).to eq(1)
+
+      logger.broadcast_to(STDOUT)
+
+      expect(::ActiveSupport::Logger.logger_outputs_to?(logger, STDOUT)).to eq(true)
+      expect(logger.broadcasts.length).to eq(2)
+
+      logger.stop_broadcasting_to(STDOUT)
+
+      expect(::ActiveSupport::Logger.logger_outputs_to?(logger, STDOUT)).to eq(false)
+      expect(logger.broadcasts.length).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Fixes #34, add tests for methods changed in #32 

Also makes `is_a?` and `kind_of?` method results consistent in `Logtail::Logger`.