### PR TITLE
L-1410 Fix build on new version of Rails (7.2-alpha)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,91 +15,91 @@ jobs:
 
       matrix:
         ruby-version:
-          - 3.2
-          - 3.1
-          - 3.0
-          - 2.7
-          - 2.6
-          - 2.5
-          - jruby-9.4.3.0
-          - jruby-9.2.14.0
-          - truffleruby-23.0.0
-          - truffleruby-22.1.0
+          - "3.2"
+          - "3.1"
+          - "3.0"
+          - "2.7"
+          - "2.6"
+          - "2.5"
+          - "jruby-9.4.3.0"
+          - "jruby-9.2.14.0"
+          - "truffleruby-23.0.0"
+          - "truffleruby-22.1.0"
         gemfile:
-          - rails-edge
-          - rails-7.1
-          - rails-7.0
-          - rails-6.1
-          - rails-6.0
-          - rails-5.2
-          - rails-5.1
-          - rails-5.0
+          - "rails-edge"
+          - "rails-7.1"
+          - "rails-7.0"
+          - "rails-6.1"
+          - "rails-6.0"
+          - "rails-5.2"
+          - "rails-5.1"
+          - "rails-5.0"
         exclude:
-          - gemfile: rails-edge
-            ruby-version: 2.6
-          - gemfile: rails-edge
-            ruby-version: 2.5
-          - gemfile: rails-edge
-            ruby-version: jruby-9.4.3.0
-          - gemfile: rails-edge
-            ruby-version: jruby-9.2.14.0
-          - gemfile: rails-edge
-            ruby-version: truffleruby-23.0.0
+          - gemfile: "rails-edge"
+            ruby-version: "2.6"
+          - gemfile: "rails-edge"
+            ruby-version: "2.5"
+          - gemfile: "rails-edge"
+            ruby-version: "jruby-9.4.3.0"
+          - gemfile: "rails-edge"
+            ruby-version: "jruby-9.2.14.0"
+          - gemfile: "rails-edge"
+            ruby-version: "truffleruby-23.0.0"
 
-          - gemfile: rails-7.1
-            ruby-version: 2.6
-          - gemfile: rails-7.1
-            ruby-version: 2.5
-          - gemfile: rails-7.1
-            ruby-version: jruby-9.4.3.0
-          - gemfile: rails-7.1
-            ruby-version: jruby-9.2.14.0
+          - gemfile: "rails-7.1"
+            ruby-version: "2.6"
+          - gemfile: "rails-7.1"
+            ruby-version: "2.5"
+          - gemfile: "rails-7.1"
+            ruby-version: "jruby-9.4.3.0"
+          - gemfile: "rails-7.1"
+            ruby-version: "jruby-9.2.14.0"
 
-          - gemfile: rails-7.0
-            ruby-version: 2.6
-          - gemfile: rails-7.0
-            ruby-version: 2.5
-          - gemfile: rails-7.0
-            ruby-version: jruby-9.2.14.0
+          - gemfile: "rails-7.0"
+            ruby-version: "2.6"
+          - gemfile: "rails-7.0"
+            ruby-version: "2.5"
+          - gemfile: "rails-7.0"
+            ruby-version: "jruby-9.2.14.0"
 
-          - gemfile: rails-5.2
-            ruby-version: 3.2
-          - gemfile: rails-5.2
-            ruby-version: 3.1
-          - gemfile: rails-5.2
-            ruby-version: 3.0
-          - gemfile: rails-5.2
-            ruby-version: jruby-9.4.3.0
-          - gemfile: rails-5.2
-            ruby-version: truffleruby-22.1.0
-          - gemfile: rails-5.2
-            ruby-version: truffleruby-23.0.0
+          - gemfile: "rails-5.2"
+            ruby-version: "3.2"
+          - gemfile: "rails-5.2"
+            ruby-version: "3.1"
+          - gemfile: "rails-5.2"
+            ruby-version: "3.0"
+          - gemfile: "rails-5.2"
+            ruby-version: "jruby-9.4.3.0"
+          - gemfile: "rails-5.2"
+            ruby-version: "truffleruby-22.1.0"
+          - gemfile: "rails-5.2"
+            ruby-version: "truffleruby-23.0.0"
 
-          - gemfile: rails-5.1
-            ruby-version: 3.2
-          - gemfile: rails-5.1
-            ruby-version: 3.1
-          - gemfile: rails-5.1
-            ruby-version: 3.0
-          - gemfile: rails-5.1
-            ruby-version: jruby-9.4.3.0
-          - gemfile: rails-5.1
-            ruby-version: truffleruby-23.0.0
-          - gemfile: rails-5.1
-            ruby-version: truffleruby-22.1.0
+          - gemfile: "rails-5.1"
+            ruby-version: "3.2"
+          - gemfile: "rails-5.1"
+            ruby-version: "3.1"
+          - gemfile: "rails-5.1"
+            ruby-version: "3.0"
+          - gemfile: "rails-5.1"
+            ruby-version: "jruby-9.4.3.0"
+          - gemfile: "rails-5.1"
+            ruby-version: "truffleruby-23.0.0"
+          - gemfile: "rails-5.1"
+            ruby-version: "truffleruby-22.1.0"
 
-          - gemfile: rails-5.0
-            ruby-version: 3.2
-          - gemfile: rails-5.0
-            ruby-version: 3.1
-          - gemfile: rails-5.0
-            ruby-version: 3.0
-          - gemfile: rails-5.0
-            ruby-version: jruby-9.4.3.0
-          - gemfile: rails-5.0
-            ruby-version: truffleruby-23.0.0
-          - gemfile: rails-5.0
-            ruby-version: truffleruby-22.1.0
+          - gemfile: "rails-5.0"
+            ruby-version: "3.2"
+          - gemfile: "rails-5.0"
+            ruby-version: "3.1"
+          - gemfile: "rails-5.0"
+            ruby-version: "3.0"
+          - gemfile: "rails-5.0"
+            ruby-version: "jruby-9.4.3.0"
+          - gemfile: "rails-5.0"
+            ruby-version: "truffleruby-23.0.0"
+          - gemfile: "rails-5.0"
+            ruby-version: "truffleruby-22.1.0"
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,10 @@ jobs:
           - "rails-5.0"
         exclude:
           - gemfile: "rails-edge"
+            ruby-version: "3.0"
+          - gemfile: "rails-edge"
+            ruby-version: "2.7"
+          - gemfile: "rails-edge"
             ruby-version: "2.6"
           - gemfile: "rails-edge"
             ruby-version: "2.5"
@@ -43,6 +47,8 @@ jobs:
             ruby-version: "jruby-9.4.3.0"
           - gemfile: "rails-edge"
             ruby-version: "jruby-9.2.14.0"
+          - gemfile: "rails-edge"
+            ruby-version: "truffleruby-22.1.0"
           - gemfile: "rails-edge"
             ruby-version: "truffleruby-23.0.0"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
 
       matrix:
         ruby-version:
+          - "3"
+          - "3.3"
           - "3.2"
           - "3.1"
           - "3.0"
@@ -69,6 +71,10 @@ jobs:
             ruby-version: "jruby-9.2.14.0"
 
           - gemfile: "rails-5.2"
+            ruby-version: "3"
+          - gemfile: "rails-5.2"
+            ruby-version: "3.3"
+          - gemfile: "rails-5.2"
             ruby-version: "3.2"
           - gemfile: "rails-5.2"
             ruby-version: "3.1"
@@ -82,6 +88,10 @@ jobs:
             ruby-version: "truffleruby-23.0.0"
 
           - gemfile: "rails-5.1"
+            ruby-version: "3"
+          - gemfile: "rails-5.1"
+            ruby-version: "3.3"
+          - gemfile: "rails-5.1"
             ruby-version: "3.2"
           - gemfile: "rails-5.1"
             ruby-version: "3.1"
@@ -94,6 +104,10 @@ jobs:
           - gemfile: "rails-5.1"
             ruby-version: "truffleruby-22.1.0"
 
+          - gemfile: "rails-5.0"
+            ruby-version: "3"
+          - gemfile: "rails-5.0"
+            ruby-version: "3.3"
           - gemfile: "rails-5.0"
             ruby-version: "3.2"
           - gemfile: "rails-5.0"

--- a/spec/logtail-rails/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/logtail-rails/action_dispatch/debug_exceptions_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Logtail::Integrations::ActionDispatch::DebugExceptions do
     end
 
     it "should log an exception event once" do
-      expect { dispatch_rails_request("/exception") }.to raise_error(RuntimeError)
+      suppress(RuntimeError) { dispatch_rails_request("/exception") }
 
       lines = clean_lines(io.string.split("\n"))
       expect(lines.length).to eq(3)

--- a/spec/logtail-rails/error_event_spec.rb
+++ b/spec/logtail-rails/error_event_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Logtail::Integrations::Rails::ErrorEvent do
     it "should log the exception" do
       allow(Benchmark).to receive(:ms).and_return(1).and_yield
 
-      expect { dispatch_rails_request("/rack_error") }.to raise_error(RuntimeError)
+      suppress(RuntimeError) { dispatch_rails_request("/rack_error") }
 
       lines = clean_lines(io.string.split("\n"))
 


### PR DESCRIPTION
Seems that in Rails 7.2, `dispatch_rails_request` doesn't raise the exception thrown inside (see https://github.com/rails/rails/pull/49951). This is irrelevant for our gem, removing expectation from tests.

Rails 7.2 will require Ruby ≥ 3.1 (see https://github.com/rails/rails/pull/50491).

Our CI check for Ruby 3.0 didn't work as expected, added missing checks for newly released ruby 3.3 and future 3.x