### PR TITLE
Add support for Sidekiq >= 7.3.0

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --require spec_helper
+--order defined

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test if RUBY_VERSION >= '2.7.0'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+
 gemspec

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.1.0'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.1.0'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.2.0'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.2.0'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 6.0.0'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 6.0.0'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 6.1.0'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 6.1.0'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.0.0'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.0.0'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.1.0'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 7.1.0'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-edge.gemfile
+++ b/gemfiles/rails-edge.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', github: 'rails/rails', branch: 'main'
-gem 'sidekiq', '>= 7.3.0', require: false, group: :test
+gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/gemfiles/rails-edge.gemfile
+++ b/gemfiles/rails-edge.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', github: 'rails/rails', branch: 'main'
+gem 'sidekiq', '>= 7.3.0', require: false, group: :test
 
 gem 'logtail'
 gem 'logtail-rack'

--- a/lib/logtail-rails.rb
+++ b/lib/logtail-rails.rb
@@ -21,7 +21,6 @@ require "logtail-rails/action_controller"
 require "logtail-rails/action_dispatch"
 require "logtail-rails/action_view"
 require "logtail-rails/active_record"
-require "logtail-rails/sidekiq"
 
 require "logtail-rails/log_entry"
 require "logtail-rails/logger"

--- a/lib/logtail-rails/logger.rb
+++ b/lib/logtail-rails/logger.rb
@@ -65,6 +65,8 @@ module Logtail
       logger = self.create_logger(io_device)
 
       if defined?(Sidekiq)
+        require "logtail-rails/sidekiq"
+
         Sidekiq.configure_server do |config|
           logger = self.create_logger(io_device, config.logger) if config.logger.class == Sidekiq::Logger
           config.logger = logger

--- a/lib/logtail-rails/sidekiq.rb
+++ b/lib/logtail-rails/sidekiq.rb
@@ -1,6 +1,7 @@
 # integrates Logtail::CurrentContext with Sidekiq::Context if installed
 
 begin
+  require 'sidekiq/component'
   require 'sidekiq/job_logger'
 
   class Sidekiq::JobLogger

--- a/logtail-rails.gemspec
+++ b/logtail-rails.gemspec
@@ -39,11 +39,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 0.8"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_development_dependency("bundler-audit", ">= 0")
-  spec.add_development_dependency("rails_stdout_logging", ">= 0")
-  spec.add_development_dependency("rspec-its", ">= 0")
-  spec.add_development_dependency("timecop", ">= 0")
-  spec.add_development_dependency('webmock', '~> 2.3')
+  spec.add_development_dependency "bundler-audit", ">= 0"
+  spec.add_development_dependency "rails_stdout_logging", ">= 0"
+  spec.add_development_dependency "rspec-its", ">= 0"
+  spec.add_development_dependency "timecop", ">= 0"
+  spec.add_development_dependency "webmock", "~> 2.3"
 
   rails_version = 0
   if ENV.key?('RAILS_VERSION')
@@ -58,6 +58,6 @@ Gem::Specification.new do |spec|
   elsif rails_version >= 3 && rails_version < 6
     spec.add_development_dependency('sqlite3', '1.3.13')
   else
-    spec.add_development_dependency('sqlite3', '~> 1.4.0')
+    spec.add_development_dependency('sqlite3', '~> 1.5.0')
   end
 end

--- a/spec/logtail-rails/logger_spec.rb
+++ b/spec/logtail-rails/logger_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe Logtail::Logger, :rails_23 => true do
     end
 
     it "should configure the Sidekiq server to use a logtail logger when required" do
+      skip "Skipping test because Sidekiq 7.3 is not available for Ruby #{RUBY_VERSION}" if RUBY_VERSION < '2.7.0'
+
       require 'sidekiq/testing'
       require 'sidekiq/cli'
 

--- a/spec/logtail-rails/logger_spec.rb
+++ b/spec/logtail-rails/logger_spec.rb
@@ -74,4 +74,33 @@ RSpec.describe Logtail::Logger, :rails_23 => true do
       expect(logger.broadcasts.length).to eq(1)
     end
   end
+
+  describe ".create_default_logger" do
+    let(:log_double) { instance_double("Sidekiq::Logger") }
+
+    before do
+      allow(Logtail::Logger).to receive(:create_logger).and_return(log_double)
+    end
+
+    it "should return the newly created logger" do
+      res = Logtail::Logger.create_default_logger("foo")
+
+      expect(res).to eq(log_double)
+    end
+
+    it "should not load Sidekiq if it hasn't been required" do
+      Logtail::Logger.create_default_logger("foo")
+
+      expect(defined?(Sidekiq)).to be nil
+    end
+
+    it "should configure the Sidekiq server to use a logtail logger when required" do
+      require 'sidekiq/testing'
+      require 'sidekiq/cli'
+
+      Logtail::Logger.create_default_logger("foo")
+
+      expect(Sidekiq.logger).to eq(log_double)
+    end
+  end
 end

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -17,6 +17,7 @@ class RailsApp < Rails::Application
   config.action_dispatch.show_exceptions = false
   config.active_support.deprecation = :stderr
   config.eager_load = false
+  config.hosts = nil
 end
 
 RailsApp.initialize!


### PR DESCRIPTION
Currently anyone using Sidekiq >= 7.3.0 will encounter the following error during application boot because `Sidekiq::Component` is not part of the public API. (See this thread).

```ruby
NameError: uninitialized constant Sidekiq::Component (NameError)

    include Sidekiq::Component
                   ^^^^^^^^^^^
```

### Changes:

 - Adds missing `rails.config.hosts` reset for dev
 - Upgrade SQLite to 1.5.0 to support M1 Mac Dev
 - Migrate Sidekiq integration directly into logger initialization method
 - Add tests for Sidekiq integration