### PR TITLE
Explicitly require mutex_m in CI for Ruby ≥ 3.4 and Rails ≤ 7.0

### DIFF
--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -6,6 +6,10 @@ gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 gem 'logtail'
 gem 'logtail-rack'
 
+if RUBY_VERSION >= "3.4.0"
+  gem 'mutex_m'
+end
+
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'
 end

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -6,6 +6,10 @@ gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 gem 'logtail'
 gem 'logtail-rack'
 
+if RUBY_VERSION >= "3.4.0"
+  gem 'mutex_m'
+end
+
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'
 end

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -6,6 +6,10 @@ gem 'sidekiq', '>= 7.3.0', require: false if RUBY_VERSION >= '2.7.0'
 gem 'logtail'
 gem 'logtail-rack'
 
+if RUBY_VERSION >= "3.4.0"
+  gem 'mutex_m'
+end
+
 if RUBY_PLATFORM == "java"
   gem 'mime-types', '2.6.2'
 end


### PR DESCRIPTION
Since Ruby 3.4, CI started to fail for Rails lower that 7.1

```
warning: mutex_m was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require "rails/railtie"

LoadError:
  cannot load such file -- mutex_m
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/notifications/fanout.rb:3:in '<top (required)>'
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/notifications.rb:4:in '<top (required)>'
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/deprecation/behaviors.rb:3:in '<top (required)>'
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/deprecation.rb:18:in '<class:Deprecation>'
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/deprecation.rb:8:in '<module:ActiveSupport>'
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/deprecation.rb:5:in '<top (required)>'
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/inflector/inflections.rb:5:in '<top (required)>'
# ./vendor/bundle/ruby/3.4.0/gems/activesupport-6.0.6.1/lib/active_support/inflector.rb:4:in '<top (required)>'
# ./vendor/bundle/ruby/3.4.0/gems/railties-6.0.6.1/lib/rails/railtie.rb:4:in '<top (required)>'
# ./lib/logtail-rails.rb:5:in '<top (required)>'
# ./spec/support/logtail.rb:1:in '<top (required)>'
# ./spec/spec_helper.rb:14:in '<top (required)>'
```