### PR TITLE
Add support for Structured Events in Rails 8.1

### DIFF
--- a/example-project/Gemfile
+++ b/example-project/Gemfile
@@ -1,19 +1,19 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.2"
+ruby "3.3.4"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.1.0"
+gem "rails", "~> 8.1.0.rc1"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.1"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 6.0"
+gem "puma", "~> 6.4"
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"

--- a/example-project/Gemfile
+++ b/example-project/Gemfile
@@ -71,4 +71,4 @@ group :test do
   gem "webdrivers"
 end
 
-gem "logtail-rails", "~> 0.2.10"
+gem "logtail-rails", "~> 0.2.11"

--- a/example-project/app/controllers/example_controller.rb
+++ b/example-project/app/controllers/example_controller.rb
@@ -36,5 +36,15 @@ class ExampleController < ApplicationController
             },
             id: 123456
         )
+
+        # Since Rails 8.1, you can also use the Rails.event to send events with structured data to Better Stack.
+        Rails.event.notify("My first event", user_id: 123, email: "user@example.com")
+        
+        # You can add context to all events
+        Rails.event.set_context(request_id: "abc123", shop_id: 456)
+        # And tags specific events
+        Rails.event.tagged("api") do
+            Rails.event.notify("My tagged event with additional context", user_id: 123, email: "user@example.com")
+        end
     end
 end

--- a/example-project/config/application.rb
+++ b/example-project/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module ExampleProject
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 8.1
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/logtail-rails.rb
+++ b/lib/logtail-rails.rb
@@ -7,6 +7,7 @@ require "active_record"
 require "rack"
 
 require "logtail-rails/active_support_log_subscriber"
+require "logtail-rails/event_log_subscriber"
 require "logtail-rails/config"
 require "logtail-rails/railtie"
 
@@ -55,6 +56,7 @@ module Logtail
         ActionController.enabled = value
         ActionView.enabled = value
         ActiveRecord.enabled = value
+        EventLogSubscriber.enabled = value
       end
 
       # All enabled middlewares. The order is relevant. Middlewares that set

--- a/lib/logtail-rails/event_log_subscriber.rb
+++ b/lib/logtail-rails/event_log_subscriber.rb
@@ -1,0 +1,58 @@
+module Logtail
+  module Integrations
+    module Rails
+      # A subscriber for Rails 8.1's Structured Event Reporting system.
+      # This subscriber receives events emitted by Rails.event.notify() and logs
+      # them with all their data to Rails.logger, which sends them to Better Stack.
+      class EventLogSubscriber
+        # Rails logger instance
+        attr_reader :logger
+
+        # Log level to use for logging events
+        mattr_accessor :log_level, default: :info
+
+        # Allows to disable the subscriber
+        mattr_accessor :enabled, default: true
+
+        # Initialize the subscriber with a logger instance
+        def initialize(logger)
+          @logger = logger
+        end
+
+        # Rails 8.1 event emission method - called when events are emitted
+        def emit(event)
+          return unless self.class.enabled
+
+          # Log the event with all its data to Rails.logger
+          # Create a structured log entry with the event data
+          tags = event[:tags]
+          tags_array = tags.is_a?(Hash) ? tags.keys : (tags.is_a?(Array) ? tags : [])
+
+          log_data = {
+            event_name: event[:name],
+            payload: event[:payload] || {},
+            context: event[:context] || {},
+            tags: tags_array,
+            source_location: event[:source_location] || {}
+          }
+
+          message = build_log_message(event)
+          logger.info("hello")
+          logger.send(self.class.log_level, message, log_data)
+        end
+
+        private
+
+        def build_log_message(event)
+          payload = event[:payload] || {}
+          payload_str = payload.map { |key, value| "#{key}=#{value}" }.join(" ")
+
+          source_location = event[:source_location] || {}
+          source_str = "at #{source_location[:filepath]}:#{source_location[:lineno]}" if source_location[:filepath] && source_location[:lineno]
+
+          "[#{event[:name]}] #{payload_str} #{source_str}".strip
+        end
+      end
+    end
+  end
+end

--- a/lib/logtail-rails/logger.rb
+++ b/lib/logtail-rails/logger.rb
@@ -78,6 +78,9 @@ module Logtail
         end
       end
 
+      # For Rails 8.1 and above, subscribe to the event system
+      Rails.event.subscribe(Logtail::Integrations::Rails::EventLogSubscriber.new(logger)) if Rails.respond_to?(:event)
+
       logger
     end
   end


### PR DESCRIPTION
Upcoming Rails 8.1 introduces [Structured Events](https://rubyonrails.org/2025/8/15/this-week-in-rails-structured-event-reporting-lands-in-rails-b4395645)

The logger will auto-subscribe to events when creating via `create_default_logger`, otherwise, you can add the subscription yourself using `Rails.event.subscribe`

It's a noop in Rails < 8.1, so there should be no worries with backward compatibility.

Updating the example project to Rails 8.1 RC1 to showcase the feature.

<img width="697" height="888" alt="image" src="https://github.com/user-attachments/assets/ca73a703-bb17-413f-bfdd-e8d0325401f6" />

