### PR TITLE
Update GitHub Actions runner to use ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -25,10 +25,7 @@ jobs:
           - "2.7"
           - "2.6"
           - "2.5"
-          - "jruby-9.4.3.0"
-          - "jruby-9.2.14.0"
-          - "truffleruby-23.0.0"
-          - "truffleruby-22.1.0"
+          - "truffleruby"
         gemfile:
           - "rails-edge"
           - "rails-8.0"
@@ -51,14 +48,6 @@ jobs:
             ruby-version: "2.6"
           - gemfile: "rails-edge"
             ruby-version: "2.5"
-          - gemfile: "rails-edge"
-            ruby-version: "jruby-9.4.3.0"
-          - gemfile: "rails-edge"
-            ruby-version: "jruby-9.2.14.0"
-          - gemfile: "rails-edge"
-            ruby-version: "truffleruby-22.1.0"
-          - gemfile: "rails-edge"
-            ruby-version: "truffleruby-23.0.0"
 
           - gemfile: "rails-8.0"
             ruby-version: "3.1"
@@ -70,14 +59,6 @@ jobs:
             ruby-version: "2.6"
           - gemfile: "rails-8.0"
             ruby-version: "2.5"
-          - gemfile: "rails-8.0"
-            ruby-version: "jruby-9.4.3.0"
-          - gemfile: "rails-8.0"
-            ruby-version: "jruby-9.2.14.0"
-          - gemfile: "rails-8.0"
-            ruby-version: "truffleruby-22.1.0"
-          - gemfile: "rails-8.0"
-            ruby-version: "truffleruby-23.0.0"
 
           - gemfile: "rails-7.2"
             ruby-version: "3.0"
@@ -87,28 +68,16 @@ jobs:
             ruby-version: "2.6"
           - gemfile: "rails-7.2"
             ruby-version: "2.5"
-          - gemfile: "rails-7.2"
-            ruby-version: "jruby-9.4.3.0"
-          - gemfile: "rails-7.2"
-            ruby-version: "jruby-9.2.14.0"
-          - gemfile: "rails-7.2"
-            ruby-version: "truffleruby-22.1.0"
           
           - gemfile: "rails-7.1"
             ruby-version: "2.6"
           - gemfile: "rails-7.1"
             ruby-version: "2.5"
-          - gemfile: "rails-7.1"
-            ruby-version: "jruby-9.4.3.0"
-          - gemfile: "rails-7.1"
-            ruby-version: "jruby-9.2.14.0"
 
           - gemfile: "rails-7.0"
             ruby-version: "2.6"
           - gemfile: "rails-7.0"
             ruby-version: "2.5"
-          - gemfile: "rails-7.0"
-            ruby-version: "jruby-9.2.14.0"
 
           - gemfile: "rails-5.2"
             ruby-version: "3"
@@ -120,12 +89,6 @@ jobs:
             ruby-version: "3.1"
           - gemfile: "rails-5.2"
             ruby-version: "3.0"
-          - gemfile: "rails-5.2"
-            ruby-version: "jruby-9.4.3.0"
-          - gemfile: "rails-5.2"
-            ruby-version: "truffleruby-22.1.0"
-          - gemfile: "rails-5.2"
-            ruby-version: "truffleruby-23.0.0"
 
           - gemfile: "rails-5.1"
             ruby-version: "3"
@@ -137,12 +100,6 @@ jobs:
             ruby-version: "3.1"
           - gemfile: "rails-5.1"
             ruby-version: "3.0"
-          - gemfile: "rails-5.1"
-            ruby-version: "jruby-9.4.3.0"
-          - gemfile: "rails-5.1"
-            ruby-version: "truffleruby-23.0.0"
-          - gemfile: "rails-5.1"
-            ruby-version: "truffleruby-22.1.0"
 
           - gemfile: "rails-5.0"
             ruby-version: "3"
@@ -154,12 +111,6 @@ jobs:
             ruby-version: "3.1"
           - gemfile: "rails-5.0"
             ruby-version: "3.0"
-          - gemfile: "rails-5.0"
-            ruby-version: "jruby-9.4.3.0"
-          - gemfile: "rails-5.0"
-            ruby-version: "truffleruby-23.0.0"
-          - gemfile: "rails-5.0"
-            ruby-version: "truffleruby-22.1.0"
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,8 @@ jobs:
             ruby-version: "3.1"
           - gemfile: "rails-5.2"
             ruby-version: "3.0"
+          - gemfile: "rails-5.2"
+            ruby-version: "truffleruby"
 
           - gemfile: "rails-5.1"
             ruby-version: "3"
@@ -100,6 +102,8 @@ jobs:
             ruby-version: "3.1"
           - gemfile: "rails-5.1"
             ruby-version: "3.0"
+          - gemfile: "rails-5.1"
+            ruby-version: "truffleruby"
 
           - gemfile: "rails-5.0"
             ruby-version: "3"
@@ -111,6 +115,8 @@ jobs:
             ruby-version: "3.1"
           - gemfile: "rails-5.0"
             ruby-version: "3.0"
+          - gemfile: "rails-5.0"
+            ruby-version: "truffleruby"
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           - "truffleruby"
         gemfile:
           - "rails-edge"
+          - "rails-8.1"
           - "rails-8.0"
           - "rails-7.2"
           - "rails-7.1"
@@ -47,6 +48,17 @@ jobs:
           - gemfile: "rails-edge"
             ruby-version: "2.6"
           - gemfile: "rails-edge"
+            ruby-version: "2.5"
+
+          - gemfile: "rails-8.1"
+            ruby-version: "3.1"
+          - gemfile: "rails-8.1"
+            ruby-version: "3.0"
+          - gemfile: "rails-8.1"
+            ruby-version: "2.7"
+          - gemfile: "rails-8.1"
+            ruby-version: "2.6"
+          - gemfile: "rails-8.1"
             ruby-version: "2.5"
 
           - gemfile: "rails-8.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
             ruby-version: "2.6"
           - gemfile: "rails-edge"
             ruby-version: "2.5"
+          - gemfile: "rails-8.1"
+            ruby-version: "truffleruby"
 
           - gemfile: "rails-8.1"
             ruby-version: "3.1"
@@ -60,6 +62,8 @@ jobs:
             ruby-version: "2.6"
           - gemfile: "rails-8.1"
             ruby-version: "2.5"
+          - gemfile: "rails-8.1"
+            ruby-version: "truffleruby"
 
           - gemfile: "rails-8.0"
             ruby-version: "3.1"

--- a/gemfiles/rails-8.1.gemfile
+++ b/gemfiles/rails-8.1.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 8.0.0'
+gem 'rails', '~> 8.1.0'
 gem 'sidekiq', '>= 7.3.0', require: false
 
 gem 'logtail'

--- a/lib/logtail-rails/active_support_log_subscriber.rb
+++ b/lib/logtail-rails/active_support_log_subscriber.rb
@@ -26,9 +26,6 @@ module Logtail
           subscriber = find(component, type)
 
           if !subscriber
-            # In Rails 8.1+, the default log subscriber might not be attached yet
-            return if ::Rails::VERSION::MAJOR > 8 || (::Rails::VERSION::MAJOR == 8 && ::Rails::VERSION::MINOR >= 1)
-
             raise "We could not find a log subscriber for #{component.inspect} of type #{type.inspect}"
           end
 

--- a/lib/logtail-rails/active_support_log_subscriber.rb
+++ b/lib/logtail-rails/active_support_log_subscriber.rb
@@ -26,6 +26,9 @@ module Logtail
           subscriber = find(component, type)
 
           if !subscriber
+            # In Rails 8.1+, the default log subscriber might not be attached yet
+            return if ::Rails::VERSION::MAJOR > 8 || (::Rails::VERSION::MAJOR == 8 && ::Rails::VERSION::MINOR >= 1)
+
             raise "We could not find a log subscriber for #{component.inspect} of type #{type.inspect}"
           end
 

--- a/logtail-rails.gemspec
+++ b/logtail-rails.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 0.8"
   spec.add_development_dependency "rspec", "~> 3.0"
 
+  spec.add_development_dependency "benchmark", ">= 0"
   spec.add_development_dependency "bundler-audit", ">= 0"
   spec.add_development_dependency "rails_stdout_logging", ">= 0"
   spec.add_development_dependency "rspec-its", ">= 0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,4 +37,13 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # Reset Logtail Config.instance.logger before each test to prevent mock leakage
+  config.before(:each) do
+    # Reset to default Rails logger proc to prevent mock leakage between tests
+    Logtail::Config.instance.logger = Proc.new { ::Rails.logger }
+
+    # Stub EventLogSubscriber#logger to prevent mock leakage from cached instances
+    allow_any_instance_of(Logtail::Integrations::Rails::EventLogSubscriber).to receive(:logger).and_return(Logtail::Config.instance.logger)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'bundler/setup'
 require 'rspec'
 require 'rspec/its'
 require 'rspec/mocks'
+require 'benchmark'
 
 # Support files, order is relevant
 require File.join(File.dirname(__FILE__), 'support', 'socket_hostname')


### PR DESCRIPTION
Similar to https://github.com/logtail/logtail-ruby/pull/41, dropping CI checks for jruby and specific versions of truffleruby due to compatibility issues with ubuntu-latest.